### PR TITLE
[feat]: add root router

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@tanstack/react-query": "^5.28.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router": "^6.22.3",
+    "react-router-dom": "^6.22.3",
     "zustand": "^4.5.2"
   },
   "devDependencies": {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App.tsx';
 import './index.css';
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RootRouter } from './router/RootRouter';
+
 const queryClient = new QueryClient();
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <App />
+      <RootRouter />
     </QueryClientProvider>
   </React.StrictMode>
 );

--- a/src/router/RootRouter.tsx
+++ b/src/router/RootRouter.tsx
@@ -1,0 +1,14 @@
+import App from '@/App';
+import {
+  createBrowserRouter,
+  RouterProvider,
+  createRoutesFromElements,
+  Route,
+} from 'react-router-dom';
+
+export const RootRouter = () => {
+  const router = createBrowserRouter(
+    createRoutesFromElements(<Route path="/" element={<App />} />)
+  );
+  return <RouterProvider router={router} />;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -413,6 +413,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@remix-run/router@1.15.3":
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.15.3.tgz#d2509048d69dbb72d5389a14945339f1430b2d3c"
+  integrity sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==
+
 "@rollup/pluginutils@^5.0.5":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.1.0.tgz#7e53eddc8c7f483a4ad0b94afb1f7f5fd3c771e0"
@@ -1912,6 +1917,21 @@ react-dom@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-router-dom@^6.22.3:
+  version "6.22.3"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.22.3.tgz#9781415667fd1361a475146c5826d9f16752a691"
+  integrity sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==
+  dependencies:
+    "@remix-run/router" "1.15.3"
+    react-router "6.22.3"
+
+react-router@6.22.3, react-router@^6.22.3:
+  version "6.22.3"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.22.3.tgz#9d9142f35e08be08c736a2082db5f0c9540a885e"
+  integrity sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==
+  dependencies:
+    "@remix-run/router" "1.15.3"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
router 폴더밑에 RootRouter로 컴포넌트 하나 만들었습니다.

경로 추가하시려면 createRoutesFromElements안에 Route컴포넌트로 path따서 만들어주면 됩니다.

```typescript
export const RootRouter = () => {
  const router = createBrowserRouter(
    // 여기에 Route 추가
    createRoutesFromElements(<Route path="/" element={<App />} />)
  );
  return <RouterProvider router={router} />;
};
```