### PR TITLE
fix: Cloudfront Path 수정

### DIFF
--- a/.github/workflows/webview-s3-deploy.yml
+++ b/.github/workflows/webview-s3-deploy.yml
@@ -67,4 +67,4 @@ jobs:
           CLOUD_FRONT_ID: ${{ secrets.AWS_CLOUDFRONT_ID }}
         run: |
           aws cloudfront create-invalidation \
-            --distribution-id $CLOUD_FRONT_ID --paths /*
+            --distribution-id $CLOUD_FRONT_ID --paths "/*"


### PR DESCRIPTION
## 🎫 없음
## 🛠️ 작업 내용
<br>
S3에 올린 후 CloudFront의 캐시를 무효화 해야 소스코드가 바로 적용 됩니다.

무효화 경로가 잘못된것으로 짐작되어 경로를 수정합니다.
<br>


## 🗒️ Note (optional)
추후 다른 소스코드 적용 후 해당 브렌치를 바로 머지하여 업데이트한 소스코드가 적용되는지 확인 부탁드립니다.