### PR TITLE
[feat]: add protectedRoute

### DIFF
--- a/src/router/ProtectedRoute.tsx
+++ b/src/router/ProtectedRoute.tsx
@@ -1,0 +1,9 @@
+import { Navigate, Outlet, useLoaderData } from 'react-router';
+
+const ProtectedRoute = () => {
+  const token = useLoaderData();
+
+  return <>{token ? <Outlet /> : <Navigate to="/" replace={true} />}</>;
+};
+
+export default ProtectedRoute;

--- a/src/router/RootRouter.tsx
+++ b/src/router/RootRouter.tsx
@@ -11,16 +11,31 @@ import {
   createRoutesFromElements,
   Route,
 } from 'react-router-dom';
+import ProtectedRoute from './ProtectedRoute';
+import { requestAPI } from '@/utils/fetch';
 
 export const RootRouter = () => {
   const router = createBrowserRouter(
     createRoutesFromElements(
       <Route path="/" element={<RootLayout />}>
-        <Route path="chat-list" element={<CharRoomsPage />} />
-        <Route path="reservation" element={<ReservationIndexPage />} />
-        <Route path="chat-list/*" element={<ChatRoomPage />} />
-        <Route path="reservation/*" element={<DetailReservation />} />
-        <Route path="payment" element={<PaymentPage />} />
+        <Route
+          element={<ProtectedRoute />}
+          loader={async () => {
+            const token = await requestAPI().get(
+              'https://pokeapi.co/api/v2/pokemon/ditto'
+            );
+            return token;
+          }}
+        >
+          <Route path="chat-list" element={<CharRoomsPage />} />
+          <Route path="reservation" element={<ReservationIndexPage />} />
+          <Route path="chat-list/:chatId" element={<ChatRoomPage />} />
+          <Route
+            path="reservation/:reservationId"
+            element={<DetailReservation />}
+          />
+          <Route path="payment" element={<PaymentPage />} />
+        </Route>
       </Route>
     )
   );


### PR DESCRIPTION
## 🎫 [지라 티켓 번호]

<br>

<br>

## 🛠️ 작업 내용
<!-- 작업 내용 (스크린샷도 같이 있으면 좋아요) -->
로그인한 유저인지 아닌지 판별해서 redirect 시켜주는 ProtectedRoute 만들었습니다.

웹에서는 로그인이나 회원가입을 진행하고 있지 않습니다.
따라서 회원인지 아닌지 판별해서 redirect하는 기능은 제외하고 로그인 유무만 판별해서 redirect하게 하였습니다.

테스트용으로 포켓몬 api를 호출중인데,
IOS쪽에서 함수가 만들어지면 해당 함수로 token판별하고 헤더에 저장하는 로직을 추가해야합니다.

<br>

<br>

## 📱 작업 화면
<!-- img src "이부분에 gif파일 넣어주시면 됩니다" -->
|화면 이름|스크린샷|
|:--:|:--:|
|ViewName|<img src = "" width ="250">|

<br>

## 🗒️ Note (optional)
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
