### PR TITLE
[feat]: add useTokenStore , apply axios interceptors

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,17 +1,13 @@
 declare global {
   interface Window {
-    webkit: Webkit;
-    iOSToJavaScript: (token: string) => void;
-  }
-
-  interface Webkit {
-    messageHandlers?: MessageHandlers;
-  }
-
-  interface MessageHandlers {
-    buttonClicked?: {
-      postMessage: (message: string) => void;
+    webkit: {
+      messageHandlers: {
+        buttonClicked: {
+          postMessage: (message: string) => void;
+        };
+      };
     };
+    iOSToJavaScript: (token: string) => void;
   }
 }
 

--- a/src/pages/Reservation/Index/Index.tsx
+++ b/src/pages/Reservation/Index/Index.tsx
@@ -17,25 +17,6 @@ const ReservationIndexPage = () => {
     console.log(res);
   };
 
-  const handleIosButton = () => {
-    alert('AccessToten');
-    if (
-      window.webkit &&
-      window.webkit.messageHandlers &&
-      window.webkit.messageHandlers.buttonClicked
-    ) {
-      window.webkit.messageHandlers.buttonClicked.postMessage('프론트엔드');
-    }
-  };
-
-  const [msg, setMsg] = useState('');
-
-  const getAccessToken = (token: string) => {
-    setMsg(token.length > 0 ? token : '토큰없음');
-  };
-
-  window.iOSToJavaScript = getAccessToken;
-
   useEffect(() => {
     fetchs();
     fetch2();
@@ -47,9 +28,6 @@ const ReservationIndexPage = () => {
       <CMCalendar />
       <div className={`Divider Reservation`} />
       <div className={styles.Title}>오전</div>
-      <div id="message" style={{ color: 'red' }}>
-        토큰 : {msg}
-      </div>
       <div className={styles.TimeWrap}>
         {times?.am?.map((item, index) => (
           <Button
@@ -74,9 +52,7 @@ const ReservationIndexPage = () => {
         ))}
       </div>
       <div className={styles.NavigateWrap}>
-        <Button onClick={handleIosButton} buttonType="Gray">
-          취소
-        </Button>
+        <Button buttonType="Gray">취소</Button>
         <Button buttonType="Primary">다음</Button>
       </div>
     </div>

--- a/src/router/RootRouter.tsx
+++ b/src/router/RootRouter.tsx
@@ -12,19 +12,24 @@ import {
   Route,
 } from 'react-router-dom';
 import ProtectedRoute from './ProtectedRoute';
-import { requestAPI } from '@/utils/fetch';
+import { setAccessToken, useTokenStore } from '@/stores/useTokenStore';
 
 export const RootRouter = () => {
+  const handleIosWebviewToken = (token: string) => {
+    if (token) setAccessToken(token);
+  };
+
+  window.iOSToJavaScript = handleIosWebviewToken;
+
+  const accessToken = useTokenStore((state) => state.accessToken);
+
   const router = createBrowserRouter(
     createRoutesFromElements(
       <Route path="/" element={<RootLayout />}>
         <Route
           element={<ProtectedRoute />}
           loader={async () => {
-            const token = await requestAPI().get(
-              'https://pokeapi.co/api/v2/pokemon/ditto'
-            );
-            return token;
+            return accessToken;
           }}
         >
           <Route path="chat-list" element={<CharRoomsPage />} />

--- a/src/stores/useTokenStore.ts
+++ b/src/stores/useTokenStore.ts
@@ -1,0 +1,12 @@
+import { create } from 'zustand';
+
+interface ITokenStore {
+  accessToken: string;
+}
+
+export const useTokenStore = create<ITokenStore>()(() => ({
+  accessToken: '',
+}));
+
+export const setAccessToken = (accessToken: string) =>
+  useTokenStore.setState({ accessToken });

--- a/src/stores/useTokenStore.ts
+++ b/src/stores/useTokenStore.ts
@@ -1,12 +1,22 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 interface ITokenStore {
   accessToken: string;
 }
 
-export const useTokenStore = create<ITokenStore>()(() => ({
-  accessToken: '',
-}));
+export const useTokenStore = create(
+  persist<ITokenStore>(
+    () => ({
+      accessToken: '',
+    }),
+    {
+      name: 'token-storage',
+    }
+  )
+);
 
 export const setAccessToken = (accessToken: string) =>
   useTokenStore.setState({ accessToken });
+
+export const logout = () => useTokenStore.persist.clearStorage;

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,8 +1,24 @@
+import { useTokenStore } from '@/stores/useTokenStore';
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
 
 export const axiosInstance: AxiosInstance = axios.create({
   baseURL: 'https://jsonplaceholder.typicode.com',
+  headers: {
+    'Content-Type': 'application/json',
+  },
 });
+
+axiosInstance.interceptors.request.use(
+  (config) => {
+    const token = useTokenStore((state) => state.accessToken);
+
+    config.headers.Authorization = token ? token : '';
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
 
 const handleResponse = (response: AxiosResponse) => {
   // if (response.status === 400) {

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -12,7 +12,7 @@ axiosInstance.interceptors.request.use(
   (config) => {
     const token = useTokenStore((state) => state.accessToken);
 
-    config.headers.Authorization = token ? token : '';
+    config.headers.Authorization = token ? `Bearer ${token}` : '';
     return config;
   },
   (error) => {


### PR DESCRIPTION
## 🎫 [지라 티켓 번호]

<br>

<br>

## 🛠️ 작업 내용
<!-- 작업 내용 (스크린샷도 같이 있으면 좋아요) -->

ios에서 받은 토큰을 전역변수로 관리하는 작업을 추가했습니다.
로직한번 확인해보시고 main에 합쳐서 배포 해보고 테스트 해봐야할것같습니다.

- zustand를 사용해서 전역변수를 관리하는 useTokenStore를 추가했습니다.
   
  ```typescript
  import { create } from 'zustand';
  interface ITokenStore {
    accessToken: string;
  }

  export const useTokenStore = create<ITokenStore>()(() => ({
    accessToken: '',
  }));

  export const setAccessToken = (accessToken: string) =>
    useTokenStore.setState({ accessToken });
  ```
  - useTokenStore라는 accessToken을 저장하는 store를 하나 만들었고 accessToken에 값을 넣어주는 함수인 setAccessToken함수를 만들어서 accessToken값을 관리하게 하였습니다. 보통 store안에 다 집어넣는 방법도있지만,
  zustand 공식문서에 무려 **"단점"** 이 없는 패턴이라고 나와있길래 한번 적용시켜봤습니다. [https://docs.pmnd.rs/zustand/guides/practice-with-no-store-actions](url)

- axios interceptors를 사용해서 token이 있을경우 header에 token을 넣어주는 로직을 추가했습니다.
  
  ```typescript
  axiosInstance.interceptors.request.use(
    (config) => {
      // token가져오는 부분
      const token = useTokenStore((state) => state.accessToken);
  
      config.headers.Authorization = token ? token : '';
      return config;
    },
    (error) => {
      return Promise.reject(error);
    }
  );
  
  ```

- window 전역객체에 iOSToJavaScript 함수를 만들어주는 로직을 RootRouter.ts에 추가했습니다.
  - reservation 페이지에 들어왔을때 window 함수를 만들어주면 실제 서비스할때는 타이밍상 늦을것같아서 페이지 들어오기전에 window 함수를 만들어서 넣어주기 위해 RootRouter에 로직을 추가하였습니다.

<br>

<br>

## 📱 작업 화면
<!-- img src "이부분에 gif파일 넣어주시면 됩니다" -->
|화면 이름|스크린샷|
|:--:|:--:|
|ViewName|<img src = "" width ="250">|

<br>

## 🗒️ Note (optional)
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
